### PR TITLE
plasma-wayland-protocols: fixed version for missing source

### DIFF
--- a/plasma-wayland-protocols/.md5sum
+++ b/plasma-wayland-protocols/.md5sum
@@ -1,1 +1,1 @@
-2ad67aea0cdf2c026d904b8c13ad7b72  plasma-wayland-protocols-1.10.tar.xz
+28ae1490011ff205cbf8d99be6dd124f  plasma-wayland-protocols-1.10.0.tar.xz

--- a/plasma-wayland-protocols/Pkgfile
+++ b/plasma-wayland-protocols/Pkgfile
@@ -4,7 +4,7 @@
 # Depends on:  extra-cmake-modules
 
 name=plasma-wayland-protocols
-version=1.10
+version=1.10.0
 release=1
 source=(https://download.kde.org/stable/$name/$name-$version.tar.xz)
 


### PR DESCRIPTION
plasma-wayland-protocols-1.10.tar.xz doesn't seem to exist at the source but plasma-wayland-protocols-1.10.0.tar.xz does.