### PR TITLE
discount: minor fix to allow building with fakeroot

### DIFF
--- a/discount/Pkgfile
+++ b/discount/Pkgfile
@@ -14,6 +14,8 @@ build() {
 	./configure.sh --prefix=/usr \
 		--shared
 
+	sed -i -e '/\/sbin\/ldconfig/d' librarian.sh
+
 	make
 	make DESTDIR=$PKG install
 }


### PR DESCRIPTION
When building with fakeroot, this ldconfig call causes a permissions issue and failure. Removing it should be harmless as pkgadd will call ldconfig anyway.